### PR TITLE
Support both mikutter 5.x (GTK3) and 4.x (GTK2).

### DIFF
--- a/README.en.org
+++ b/README.en.org
@@ -10,10 +10,20 @@ The goal of this repository, regain Twitter functions to your mikutter as third-
 
 ** Auto installation
 
+*** for mikutter 5.0 and later
+
 IT IS MIKUTTER POWER! Awesome mikutter power.
 
 #+BEGIN_SRC sh
-mkdir -p ~/.mikutter/plugin/ && for i in api_request_file_cache direct_message followingcontrol home_timeline list list_for_profile list_settings mentions message_detail_view message_favorite message_retweet ratelimit rest saved_search streaming twitter twitter_activity twitter_datasource twitter_settings user_detail_view; do git clone https://github.com/mikutter/$i.git ~/.mikutter/plugin/$i; done
+mkdir -p ~/.mikutter && git clone https://github.com/mikutter/twitter_bootstrap ~/.mikutter/twitter_bootstrap && (cd ~/.mikutter/twitter_bootstrap && sh twitter-bootstrap.sh)
+#+END_SRC
+
+*** for mikutter 4.x
+
+Needs to fetch gtk2 versions for GTK dependent plugins.
+
+#+BEGIN_SRC sh
+mkdir -p ~/.mikutter && git clone https://github.com/mikutter/twitter_bootstrap ~/.mikutter/twitter_bootstrap && (cd ~/.mikutter/twitter_bootstrap && sh twitter-bootstrap_mikutter4.sh)
 #+END_SRC
 
 ** twitter_api_keys

--- a/README.org
+++ b/README.org
@@ -10,10 +10,21 @@ mikutter 4.0ではTwitterプラグインが標準で非対応になりました�
 
 ** 自動でインストールできるプラグイン
 
-以下のコマンドを実行して、mikutterを起動してください。mikutter 4.0以降のための手順となるため、3.xで実行した場合どうなるか分かりません。
+*** mikutter 5.0 以降の場合
+
+以下のコマンドを実行して、mikutterを起動してください。
 
 #+BEGIN_SRC sh
-mkdir -p ~/.mikutter/plugin/ && for i in api_request_file_cache direct_message followingcontrol home_timeline list list_for_profile list_settings mentions message_detail_view message_favorite message_retweet ratelimit rest saved_search streaming twitter twitter_activity twitter_datasource twitter_settings user_detail_view; do git clone https://github.com/mikutter/$i.git ~/.mikutter/plugin/$i; done
+mkdir -p ~/.mikutter && git clone https://github.com/mikutter/twitter_bootstrap ~/.mikutter/twitter_bootstrap && (cd ~/.mikutter/twitter_bootstrap && sh twitter-bootstrap.sh)
+#+END_SRC
+
+*** mikutter 4.x の場合
+
+以下のコマンドを実行して、mikutterを起動してください。
+GTKに依存するプラグインについて gtk2 対応バージョンを取得します。
+
+#+BEGIN_SRC sh
+mkdir -p ~/.mikutter && git clone https://github.com/mikutter/twitter_bootstrap ~/.mikutter/twitter_bootstrap && (cd ~/.mikutter/twitter_bootstrap && sh twitter-bootstrap_mikutter4.sh)
 #+END_SRC
 
 ** twitter_api_keysのセットアップ

--- a/twitter-bootstrap.sh
+++ b/twitter-bootstrap.sh
@@ -10,7 +10,7 @@ fi
 plugindir=~/.mikutter/plugin
 mkdir -p $plugindir
 
-# GTK independent plugins
+# GTK and diva independent plugins
 for plugin in \
  api_request_file_cache \
  direct_message \
@@ -22,7 +22,6 @@ for plugin in \
  rest \
  saved_search \
  streaming \
- twitter \
  twitter_activity \
  twitter_datasource \
  twitter_settings \
@@ -30,7 +29,7 @@ for plugin in \
  git clone https://github.com/mikutter/$plugin.git $plugindir/$plugin
 done
 
-# GTK dependent plugins
+# GTK and diva dependent plugins
 for plugin_gtk in \
  followingcontrol \
  list_for_profile \
@@ -38,6 +37,7 @@ for plugin_gtk in \
  message_detail_view \
  message_retweet \
  user_detail_view \
+ twitter \
 ; do
  git clone https://github.com/mikutter/$plugin_gtk.git $opt $plugindir/$plugin_gtk
 done

--- a/twitter-bootstrap.sh
+++ b/twitter-bootstrap.sh
@@ -1,3 +1,43 @@
 #!/bin/sh
 
-mkdir -p ~/.mikutter/plugin/ && for i in api_request_file_cache direct_message followingcontrol home_timeline list list_for_profile list_settings mentions message_detail_view message_favorite message_retweet ratelimit rest saved_search streaming twitter twitter_activity twitter_datasource twitter_settings user_detail_view; do git clone https://github.com/mikutter/$i.git ~/.mikutter/plugin/$i; done
+branch=$1
+if [ "$branch" = "mikutter4" ]; then
+ opt="--branch mikutter4"
+else
+ opt=""
+fi
+
+plugindir=~/.mikutter/plugin
+mkdir -p $plugindir
+
+# GTK independent plugins
+for plugin in \
+ api_request_file_cache \
+ direct_message \
+ home_timeline \
+ list \
+ mentions \
+ message_favorite \
+ ratelimit \
+ rest \
+ saved_search \
+ streaming \
+ twitter \
+ twitter_activity \
+ twitter_datasource \
+ twitter_settings \
+; do
+ git clone https://github.com/mikutter/$plugin.git $plugindir/$plugin
+done
+
+# GTK dependent plugins
+for plugin_gtk in \
+ followingcontrol \
+ list_for_profile \
+ list_settings \
+ message_detail_view \
+ message_retweet \
+ user_detail_view \
+; do
+ git clone https://github.com/mikutter/$plugin_gtk.git $opt $plugindir/$plugin_gtk
+done

--- a/twitter-bootstrap_mikutter4.sh
+++ b/twitter-bootstrap_mikutter4.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./twitter-bootstrap.sh mikutter4


### PR DESCRIPTION
GTK2 の mikutter 4.x 系と
GTK3 の mikutter 5.x 系と
いずれでも使えるようにする変更です。

* ワンライナーはあきらめて twitter-bootstrap.sh を複数行スクリプトとする
	*  README でもスクリプトを含むこの twitter_bootstrap リポジトリを git clone してその中のスクリプトを実行させるワンライナーにする
	* twitter_bootstrap の git clone 先はとりあえず雑に ~/.mikutter 直下
	（ ~/.mikutter/twitter_bootstrap という不要な履歴ゴミが残る）
* twitter-bootstrap.sh では、GTK3およびその他のに依存しないプラグインとGTK依存のプラグインを分けてプラグイン変数を定義する
	* twitter-bootstrap.sh は引数で mikutter4 指定を判別するようにして twitter-bootstrap_mikutter4.sh では引数指定で twitter-bootstrap.sh を呼ぶ構成
* GTK依存（mikutter4依存）の各プラグインについては mikutter4 のブランチを git clone する
	* twitter-bootstrap.sh において GTK2 依存プラグインについては git clone --branch mikutter4 を指定して clone する

とりあえず ubuntu 20.04 VM上で mikutter master と mikutter develop それぞれで
Twitter world 登録できるところまではざっくりテストはしましたが、
git clone 先の URL についてはマージ前では手編集しないとテストできないので、
あらためて確認必要かも……